### PR TITLE
add '?cache=shared' option to default sqlite3 path

### DIFF
--- a/logstash_async/handler.py
+++ b/logstash_async/handler.py
@@ -36,7 +36,7 @@ class AsynchronousLogstashHandler(Handler):
     # ----------------------------------------------------------------------
     def __init__(self, host, port=5959, transport='logstash_async.transport.TcpTransport',
                  ssl_enable=False, ssl_verify=True, keyfile=None, certfile=None, ca_certs=None,
-                 database_path=':memory:', enable=True):
+                 database_path=':memory:?cache=shared', enable=True):
         super(AsynchronousLogstashHandler, self).__init__()
         self._host = host
         self._port = port


### PR DESCRIPTION
previously, the default value for database_path wasn't functional,
because every connection to ':memory:' creates a new database by
default. The '?cache=shared' option allows multiple connections to
access the same in-memory db.