### PR TITLE
Fix cyrillic (and other non-ASCII) utf8-representation troubles. In v…

### DIFF
--- a/logstash_async/formatter.py
+++ b/logstash_async/formatter.py
@@ -33,12 +33,14 @@ LOGSTASH_MESSAGE_FIELD_LIST = [
 class LogstashFormatter(logging.Formatter):
 
     # ----------------------------------------------------------------------
-    def __init__(self, message_type='python-logstash', tags=None, fqdn=False, extra_prefix='extra', extra=None):
+    def __init__(self, message_type='python-logstash', tags=None, fqdn=False, extra_prefix='extra', extra=None,
+                 ensure_ascii=True):
         super(LogstashFormatter, self).__init__()
         self._message_type = message_type
         self._tags = tags if tags is not None else []
         self._extra_prefix = extra_prefix
         self._extra = extra
+        self._ensure_ascii = ensure_ascii
 
         self._interpreter = None
         self._interpreter_version = None
@@ -201,7 +203,7 @@ class LogstashFormatter(logging.Formatter):
         if sys.version_info < (3, 0):
             return json.dumps(message)
         else:
-            return bytes(json.dumps(message), 'utf-8')
+            return bytes(json.dumps(message, ensure_ascii=self._ensure_ascii), 'utf-8')
 
 
 class DjangoLogstashFormatter(LogstashFormatter):

--- a/logstash_async/handler.py
+++ b/logstash_async/handler.py
@@ -38,7 +38,7 @@ class AsynchronousLogstashHandler(Handler):
     # ----------------------------------------------------------------------
     def __init__(self, host, port, database_path, transport='logstash_async.transport.TcpTransport',
                  ssl_enable=False, ssl_verify=True, keyfile=None, certfile=None, ca_certs=None,
-                 enable=True, ensure_ascii=True):
+                 enable=True):
         super(AsynchronousLogstashHandler, self).__init__()
         self._host = host
         self._port = port
@@ -50,7 +50,6 @@ class AsynchronousLogstashHandler(Handler):
         self._certfile = certfile
         self._ca_certs = ca_certs
         self._enable = enable
-        self._ensure_ascii = ensure_ascii
         self._transport = None
         self._setup_transport()
 
@@ -121,7 +120,7 @@ class AsynchronousLogstashHandler(Handler):
     # ----------------------------------------------------------------------
     def _create_formatter_if_necessary(self):
         if self.formatter is None:
-            self.formatter = LogstashFormatter(ensure_ascii=self._ensure_ascii)
+            self.formatter = LogstashFormatter()
 
     # ----------------------------------------------------------------------
     def close(self):

--- a/logstash_async/handler.py
+++ b/logstash_async/handler.py
@@ -29,6 +29,8 @@ class AsynchronousLogstashHandler(Handler):
     :param ca_certs: The path to the file containing recognized CA certificates.
     :param enable Flag to enable log processing (default is True, disabling
                   might be handy for local testing, etc.)
+    :param ensure_ascii Will be  all non-ASCII characters in the output escaped with \uXXXX sequences
+                        (default is True)
     """
 
     _worker_thread = None
@@ -36,7 +38,7 @@ class AsynchronousLogstashHandler(Handler):
     # ----------------------------------------------------------------------
     def __init__(self, host, port, database_path, transport='logstash_async.transport.TcpTransport',
                  ssl_enable=False, ssl_verify=True, keyfile=None, certfile=None, ca_certs=None,
-                 enable=True):
+                 enable=True, ensure_ascii=True):
         super(AsynchronousLogstashHandler, self).__init__()
         self._host = host
         self._port = port
@@ -48,6 +50,7 @@ class AsynchronousLogstashHandler(Handler):
         self._certfile = certfile
         self._ca_certs = ca_certs
         self._enable = enable
+        self._ensure_ascii = ensure_ascii
         self._transport = None
         self._setup_transport()
 
@@ -118,7 +121,7 @@ class AsynchronousLogstashHandler(Handler):
     # ----------------------------------------------------------------------
     def _create_formatter_if_necessary(self):
         if self.formatter is None:
-            self.formatter = LogstashFormatter()
+            self.formatter = LogstashFormatter(ensure_ascii=self._ensure_ascii)
 
     # ----------------------------------------------------------------------
     def close(self):


### PR DESCRIPTION
…er. 1.2.0  all non-ASCII characters in the output escaped with \uXXXX sequence. Now this is optional.