### PR TITLE
Adding in-memory cache & TTL capabilities

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -7,7 +7,7 @@ https://github.com/vklochan/python-logstash.
 It adds the following features:
 
   * Asynchronous transport of log events
-  * Store log events temporarily in a SQLite database until transport
+  * Store log events temporarily in a cache until transport
     to the Logstash server has been successful
   * Transport of events via TCP and UDP, in the future hopefully via
     the Beats protocol
@@ -29,7 +29,7 @@ So this handler will accept log events and pass them for further
 processing to a separate worker thread which will try to send
 the events to the configured Logstash server asynchronously.
 If sending the events fails, the events are stored in a
-local SQLite database for a later sending attempt.
+local cache for a later sending attempt.
 
 Whenever the application stops, to be more exact whenever
 Python' logging subsystem is shutdown, the worker thread
@@ -50,6 +50,12 @@ License
 
 ChangeLog
 ---------
+
+1.X.X (Sep 05 2017)
+++++++++++++++++++++
+
+  * Added in-memory cache back (see #12)
+  * Added support for TTL of messages
 
 
 1.2.0 (May 06, 2017)

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -50,6 +50,11 @@ enable
     Flag to enable log processing (default is True, disabling
     might be handy for local testing, etc.)
 
+event_ttl
+    TTL for messages that are waiting to be published. (default: None)
+    If a message is beyond it's TTL, it will be deleted from the cache
+    and will not be published to logstash.
+
 
 Options for configuring the log formatter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,4 +26,5 @@ Contents
    installation.rst
    usage.rst
    config.rst
+   persistence.rst
    config_logstash.rst

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -1,0 +1,12 @@
+Persistence
+-----------
+
+By default, you do not need to provide a :code:`database_path` to the :code:`AsynchronousLogstashHandler`.
+There are a couple of things you should keep in mind if you choose to go down this path.
+With no database, the backend is a simple in-memory cache. Because it is in memory, your
+messages will not be kept across process restarts. This means **it is possible to lose
+messages**. If you cannot lose messages, then you should set the :code:`database_path` option.
+
+In addition, you can also set a TTL to live on all of the messages that should be published. Simply
+pass :code:`event_ttl` to the initializer and your events will be aged off from the cache. The TTL
+is in seconds.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,6 +17,10 @@ sends Logstash messages using UDP and TCP. For example:
   test_logger.setLevel(logging.INFO)
   test_logger.addHandler(AsynchronousLogstashHandler(
       host, port, database_path='logstash.db')))
+
+  # If you don't want to write to a SQLite database, then you do
+  # not have to specify a database_path.
+  # NOTE: Without a database, messages are lost between process restarts.
   # test_logger.addHandler(AsynchronousLogstashHandler(host, port))
 
   test_logger.error('python-logstash-async: test logstash error message.')
@@ -136,4 +140,3 @@ This would result in a Logstash event like the following
         "program": "manage.py",
         "type": "python-logstash"
     }
-

--- a/example1.py
+++ b/example1.py
@@ -20,7 +20,7 @@ test_logger.debug('python-logstash-async: test logstash debug message.')
 
 try:
     1 / 0
-except Exception, e:
+except Exception as e:
     test_logger.exception(u'Exception: %s', e)
 
 # add extra field to logstash message

--- a/example2.py
+++ b/example2.py
@@ -36,4 +36,3 @@ extra = {
     'test_list': [1, 2, '3'],
 }
 test_logger.info('python-logstash: test extra fields', extra=extra)
-

--- a/logstash_async/__init__.py
+++ b/logstash_async/__init__.py
@@ -4,3 +4,7 @@
 # of the MIT license.  See the LICENSE file for details.
 
 __version__ = '1.2.0'
+
+# When using an in-memory only cache, this persists the cache through
+# thread failures, shutdowns, and restarts.
+EVENT_CACHE = {}

--- a/logstash_async/cache.py
+++ b/logstash_async/cache.py
@@ -1,0 +1,60 @@
+import abc
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Cache(object):
+
+    # ----------------------------------------------------------------------
+    @abc.abstractmethod
+    def add_event(self, event):
+        """Add the event to the cache.
+
+        This method is meant to be called by various other threads.
+        All other methods in this class are for caching messages and
+        will be called by the log processing worker threads.
+
+        :param str event: A log message
+        :return:
+        """
+        pass
+
+    # ----------------------------------------------------------------------
+    @abc.abstractmethod
+    def get_queued_events(self):
+        """Get pending events and mark them to be deleted
+
+        :return: A list of events to be published
+        """
+        pass
+
+    # ----------------------------------------------------------------------
+    @abc.abstractmethod
+    def requeue_queued_events(self, events):
+        """Mark pending_delete for events passed in to False.
+
+        Used when an error occurs attempting to publish to logstash. Upon
+        failure, we rollback the deletion flag to False.
+
+        :param events:
+        :return:
+        """
+        pass
+
+    # ----------------------------------------------------------------------
+    @abc.abstractmethod
+    def delete_queued_events(self):
+        """Delete events marked for deletion
+
+        :return:
+        """
+        pass
+
+    # ----------------------------------------------------------------------
+    @abc.abstractmethod
+    def expire_events(self):
+        """Expire events older than the TTL. If no TTL is set, no action is taken.
+
+        :return:
+        """
+        pass

--- a/logstash_async/memory_cache.py
+++ b/logstash_async/memory_cache.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# This software may be modified and distributed under the terms
+# of the MIT license.  See the LICENSE file for details.
+
+import uuid
+from logging import getLogger as get_logger
+from datetime import datetime, timedelta
+from logstash_async.cache import Cache
+
+
+class MemoryCache(Cache):
+    """Backend implementation for python-logstash-async. Keeps messages in a local, in-memory cache
+    while attempting to publish them to logstash. Does not persist through process restarts. Also,
+    does not write to disk.
+
+    :param cache: Usually just an empty dictionary
+    :param event_ttl: Optional parameter used to expire events in the cache after a time
+    """
+
+    logger = get_logger(__name__)
+
+    # ----------------------------------------------------------------------
+    def __init__(self, cache, event_ttl=None):
+        self._cache = cache
+        self._event_ttl = event_ttl
+
+    # ----------------------------------------------------------------------
+    def add_event(self, event):
+        event_id = uuid.uuid4()
+        self._cache[event_id] = {
+            "event_text": event,
+            "pending_delete": False,
+            "entry_date": datetime.now(),
+            "id": event_id
+        }
+
+    # ----------------------------------------------------------------------
+    def get_queued_events(self):
+        events = []
+        for event in self._cache.values():
+            if not event['pending_delete']:
+                events.append(event)
+                event['pending_delete'] = True
+        return events
+
+    # ----------------------------------------------------------------------
+    def requeue_queued_events(self, events):
+        for event in events:
+            event_to_queue = self._cache.get(event['id'], None)
+            # If they gave us an event which is not in the cache,
+            # there is really nothing for us to do. Right now
+            # this use-case does not raise an error. Instead, we
+            # just log the message.
+            if event_to_queue:
+                event_to_queue['pending_delete'] = False
+            else:
+                self.logger.warn("Could not requeue event with id (%s). It does not appear to be in the cache." % event['id'])
+
+    # ----------------------------------------------------------------------
+    def delete_queued_events(self):
+        ids_to_delete = [event['id'] for event in self._cache.values() if event['pending_delete']]
+        self._delete_events(ids_to_delete)
+
+    # ----------------------------------------------------------------------
+    def expire_events(self):
+        if self._event_ttl is None:
+            return
+
+        delete_time = datetime.now() - timedelta(seconds=self._event_ttl)
+        ids_to_delete = [event['id'] for event in self._cache.values() if event['entry_date'] < delete_time]
+        self._delete_events(ids_to_delete)
+
+    # ----------------------------------------------------------------------
+    def _delete_events(self, ids_to_delete):
+        for event_id in ids_to_delete:
+            # If the event is not in the cache, is there anything
+            # that we can do. This currently doesn't throw an error.
+            event = self._cache.pop(event_id, None)
+            if not event:
+                self.logger.warn("Could not delete event with id (%s). It does not appear to be in the cache." % event_id)

--- a/test/database_test.py
+++ b/test/database_test.py
@@ -1,0 +1,107 @@
+import unittest
+import os
+import sqlite3
+from logstash_async.database import DatabaseCache, DATABASE_SCHEMA_STATEMENTS
+
+
+class DatabaseCacheTest(unittest.TestCase):
+
+    TEST_DB_FILENAME = "test.db"
+    _connection = None
+
+    @classmethod
+    def setUpClass(cls):
+        if os.path.isfile(cls.TEST_DB_FILENAME):
+            os.remove(cls.TEST_DB_FILENAME)
+
+    def setUp(self):
+        self.cache = DatabaseCache(self.TEST_DB_FILENAME)
+
+    def tearDown(self):
+        stmt = "DELETE FROM `event`;"
+        self.cache._open()
+        with self.cache._connection as conn:
+            conn.execute(stmt)
+        self.cache._close()
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isfile(cls.TEST_DB_FILENAME):
+            os.remove(cls.TEST_DB_FILENAME)
+
+    @classmethod
+    def get_connection(cls):
+        if cls._connection:
+            return cls._connection
+
+        cls._connection = sqlite3.connect(cls.TEST_DB_FILENAME, isolation_level='EXCLUSIVE')
+        cls._connection.row_factory = sqlite3.Row
+        for statement in DATABASE_SCHEMA_STATEMENTS:
+            cls._connection.cursor().execute(statement)
+        return cls._connection
+
+    @classmethod
+    def close_connection(cls):
+        if cls._connection:
+            cls._connection.close()
+        cls._connection = None
+
+    def test_add_event(self):
+        self.cache.add_event("message")
+        conn = self.get_connection()
+        events = conn.cursor().execute('SELECT `event_text`, `pending_delete` FROM `event`;').fetchall()
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event['event_text'], 'message')
+
+    def test_get_queued_events(self):
+        self.cache.add_event("message")
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 1)
+
+    def test_get_queued_events_set_delete_flag(self):
+        self.cache.add_event("message")
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 1)
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 0)
+
+    def test_requeue_queued_events(self):
+        self.cache.add_event("message")
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 1)
+        self.cache.requeue_queued_events(events)
+
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 1)
+
+    def test_delete_queued_events(self):
+        self.cache.add_event('message')
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 1)
+        self.cache.get_queued_events()
+        self.cache.delete_queued_events()
+
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 0)
+
+    def test_dont_delete_unqueued_events(self):
+        self.cache.add_event('message')
+        self.cache.delete_queued_events()
+
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 1)
+
+    def test_expire_events(self):
+        import time
+        self.cache._event_ttl = 0
+        self.cache.add_event('message')
+        time.sleep(1)
+        self.cache.expire_events()
+
+        events = self.cache.get_queued_events()
+        self.assertEqual(len(events), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/memory_cahe_test.py
+++ b/test/memory_cahe_test.py
@@ -1,0 +1,55 @@
+import unittest
+import datetime
+
+from logstash_async.memory_cache import MemoryCache
+
+
+class MemoryCacheTest(unittest.TestCase):
+
+    def test_add_event(self):
+        cache = MemoryCache({})
+        cache.add_event("message")
+        self.assertEqual(len(cache._cache), 1)
+        event = list(cache._cache.values())[0]
+        self.assertEqual(event['event_text'], 'message')
+        self.assertEqual(event['pending_delete'], False)
+
+    def test_get_queued_events(self):
+        cache = MemoryCache({
+            "id1": {"pending_delete": True},
+            "id2": {"pending_delete": False}
+        })
+        self.assertEqual(len(cache.get_queued_events()), 1)
+
+    def test_get_queued_events_pending_delete_check(self):
+        cache = MemoryCache({
+            "id1": {"pending_delete": False}
+        })
+        queued_events = cache.get_queued_events()
+        self.assertEqual(len(queued_events), 1)
+        self.assertTrue(queued_events[0])
+
+
+    def test_requeue_queued_events(self):
+        cache = MemoryCache({
+            "id1": {"pending_delete": True}
+        })
+        self.assertEqual(len(cache.get_queued_events()), 0)
+        cache.requeue_queued_events([{"id": "id1"}])
+        self.assertEqual(len(cache.get_queued_events()), 1)
+
+    def test_delete_queued_events(self):
+        cache = MemoryCache({
+            "id1": {"pending_delete": True, "id": "id1"},
+            "id2": {"pending_delete": False, "id": "id2"}
+        })
+        cache.delete_queued_events()
+        self.assertEqual(len(cache._cache), 1)
+
+    def test_expire_events(self):
+        cache = MemoryCache({
+            "id1": {"pending_delete": False, "id": "id1", "entry_date": datetime.datetime.fromtimestamp(0)},
+            "id2": {"pending_delete": False, "id": "id2", "entry_date": datetime.datetime.now()}
+        }, event_ttl=100)
+        cache.expire_events()
+        self.assertEqual(len(cache._cache), 1)


### PR DESCRIPTION
This pull request allows no `database_path` to be set in the configuration.  Instead, defaulting back to a basic in-memory cache. See #11 for more details. The implementation feels pretty naive and makes me think I've overlooked something, so I'd love some feedback.

I've added test for most of the parts that I've touched. I wasn't exactly sure this was the testing style you wanted. Technically the `database_test.py` is more of an integration test than a unit test. We can take it out if you'd like. 

The pull request is not quite finished yet as I have not updated any documentation, but I wanted to get your opinion before I updated docs and continued writing tests. I'd really like to do the following:

* Update docs
* Refactor the connection code in `database.py` (mostly just create a contextmanager for the connect portions
* Write more tests