### PR TITLE
Handled possible case of non-bytes result from self.formatted.format

### DIFF
--- a/logstash_async/handler.py
+++ b/logstash_async/handler.py
@@ -5,7 +5,7 @@
 
 from logging import Handler
 
-from six import string_types
+from six import string_types, text_type
 
 import logstash_async
 from logstash_async.formatter import LogstashFormatter
@@ -39,7 +39,7 @@ class AsynchronousLogstashHandler(Handler):
     # ----------------------------------------------------------------------
     def __init__(self, host, port, database_path, transport='logstash_async.transport.TcpTransport',
                  ssl_enable=False, ssl_verify=True, keyfile=None, certfile=None, ca_certs=None,
-                 enable=True, event_ttl=None):
+                 enable=True, event_ttl=None, encoding='utf-8'):
         super(AsynchronousLogstashHandler, self).__init__()
         self._host = host
         self._port = port
@@ -53,6 +53,7 @@ class AsynchronousLogstashHandler(Handler):
         self._enable = enable
         self._transport = None
         self._event_ttl = event_ttl
+        self._encoding = encoding
         self._setup_transport()
 
     # ----------------------------------------------------------------------
@@ -124,7 +125,10 @@ class AsynchronousLogstashHandler(Handler):
     # ----------------------------------------------------------------------
     def _format_record(self, record):
         self._create_formatter_if_necessary()
-        return self.formatter.format(record) + b'\n'
+        formatted = self.formatter.format(record)
+        if isinstance(formatted, text_type):
+            formatted = formatted.encode(self._encoding)
+        return formatted + b'\n'
 
     # ----------------------------------------------------------------------
     def _create_formatter_if_necessary(self):


### PR DESCRIPTION
I stumbled upon the problem similar to https://github.com/vklochan/python-logstash/issues/30 while using python-logstash-async with https://github.com/madzak/python-json-logger on Python 3.6:

```
Traceback (most recent call last):
  File "/Users/rmihael/Documents/Projects/trade/python-logstash-async/logstash_async/handler.py", line 68, in emit
    data = self._format_record(record)
  File "/Users/rmihael/Documents/Projects/trade/python-logstash-async/logstash_async/handler.py", line 127, in _format_record
    return self.formatter.format(record) + b'\n'
TypeError: must be str, not bytes
```

Returning text type instead of bytes from `format` seems normal to me. Handler appears to be a proper place to handle encoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eht16/python-logstash-async/18)
<!-- Reviewable:end -->
