### PR TITLE
Use worker-scoped cache when using the in-memory database

### DIFF
--- a/logstash_async/__init__.py
+++ b/logstash_async/__init__.py
@@ -4,7 +4,3 @@
 # of the MIT license.  See the LICENSE file for details.
 
 __version__ = '1.4.1'
-
-# When using an in-memory only cache, this persists the cache through
-# thread failures, shutdowns, and restarts.
-EVENT_CACHE = {}

--- a/logstash_async/handler.py
+++ b/logstash_async/handler.py
@@ -7,7 +7,6 @@ from logging import Handler
 
 from six import string_types, text_type
 
-import logstash_async
 from logstash_async.formatter import LogstashFormatter
 from logstash_async.utils import import_string, safe_log_via_print
 from logstash_async.worker import LogProcessingWorker
@@ -112,7 +111,6 @@ class AsynchronousLogstashHandler(Handler):
             certfile=self._certfile,
             ca_certs=self._ca_certs,
             database_path=self._database_path,
-            cache=logstash_async.EVENT_CACHE,
             event_ttl=self._event_ttl)
         AsynchronousLogstashHandler._worker_thread.start()
 

--- a/logstash_async/worker.py
+++ b/logstash_async/worker.py
@@ -37,7 +37,6 @@ class LogProcessingWorker(Thread):
         self._certfile = kwargs.pop('certfile')
         self._ca_certs = kwargs.pop('ca_certs')
         self._database_path = kwargs.pop('database_path')
-        self._memory_cache = kwargs.pop('cache')
         self._event_ttl = kwargs.pop('event_ttl')
 
         super(LogProcessingWorker, self).__init__(*args, **kwargs)
@@ -109,7 +108,8 @@ class LogProcessingWorker(Thread):
         if self._database_path:
             self._database = DatabaseCache(path=self._database_path, event_ttl=self._event_ttl)
         else:
-            self._database = MemoryCache(cache=self._memory_cache, event_ttl=self._event_ttl)
+            cache = dict()
+            self._database = MemoryCache(cache=cache, event_ttl=self._event_ttl)
 
     # ----------------------------------------------------------------------
     def _fetch_events(self):


### PR DESCRIPTION
Instead of using a process wide global memory cache for the in-memory
database, use a cache which is unique for a single worker thread.
In reality, this shouldn't make a difference in the behaviour but avoids
globals.
Loosely related to #25.