### PR TITLE
Socket timeout setting ignored for filebeat

### DIFF
--- a/logstash_async/transport.py
+++ b/logstash_async/transport.py
@@ -155,7 +155,7 @@ class BeatsTransport(object):
             certfile,
             ca_certs,
             timeout=TimeoutNotSet):
-        timeout_ = None if timeout is not TimeoutNotSet else timeout
+        timeout_ = None if timeout is TimeoutNotSet else timeout
         self._client_arguments = dict(
             host=host,
             port=port,


### PR DESCRIPTION
Due to a bad comparisson, the socket timeout for lostash_async was ignored when using the filebeat transport.