### PR TITLE
Test for simple types first

### DIFF
--- a/logstash_async/formatter.py
+++ b/logstash_async/formatter.py
@@ -131,27 +131,23 @@ class LogstashFormatter(logging.Formatter):
 
     # ----------------------------------------------------------------------
     def _get_record_fields(self, record):
-        def value_repr(value):
-            easy_types = (type(None), bool, str, int, float)
+        return {k: self._value_repr(v) for k, v in record.__dict__.items()}
 
-            if isinstance(value, dict):
-                return {k: value_repr(v) for k, v in value.items()}
-            elif isinstance(value, (tuple, list)):
-                return [value_repr(v) for v in value]
-            elif isinstance(value, (datetime, date)):
-                return self._format_timestamp(time.mktime(value.timetuple()))
-            elif isinstance(value, uuid.UUID):
-                return value.hex
-            elif isinstance(value, easy_types):
-                return value
-            else:
-                return repr(value)
+    def _value_repr(self, value):
+        easy_types = (type(None), bool, str, int, float)
 
-        fields = {}
-
-        for key, value in record.__dict__.items():
-            fields[key] = value_repr(value)
-        return fields
+        if isinstance(value, easy_types):
+            return value
+        elif isinstance(value, (datetime, date)):
+            return self._format_timestamp(time.mktime(value.timetuple()))
+        elif isinstance(value, uuid.UUID):
+            return value.hex
+        elif isinstance(value, dict):
+            return {k: self._value_repr(v) for k, v in value.items()}
+        elif isinstance(value, (tuple, list)):
+            return [self._value_repr(v) for v in value]
+        else:
+            return repr(value)
 
     # ----------------------------------------------------------------------
     def _get_extra_fields(self, record):


### PR DESCRIPTION
When building the logstash JSON document, the `_get_record_fields` tests for various types to provide a sane default configuration to convert values into JSON-serializable values.
We noticed that the `_get_record_fields` spend a lot of time in `isinstance` checks, which hurts performance as it has to check every entry in the class hierarchy. Before, `_get_record_fields` would do 4 extra `isinstance` tests before deciding that the value can be passed along without modification. Since most log kwargs are probably simple types, reorder the tests so that simple types are tested first.

Additionally, move the inner `value_repr` into the class to allow subclasses to override the implementation without having to reimplement `_get_record_fields`.