### PR TITLE
Performance improvements

### DIFF
--- a/logstash_async/constants.py
+++ b/logstash_async/constants.py
@@ -32,11 +32,11 @@ class Constants:
     # Usually this list does not need to be modified. Add/Remove elements to
     # exclude/include them in the Logstash event, for the full list see:
     # http://docs.python.org/library/logging.html#logrecord-attributes
-    FORMATTER_RECORD_FIELD_SKIP_LIST = [
+    FORMATTER_RECORD_FIELD_SKIP_LIST = {
         'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
         'funcName', 'id', 'levelname', 'levelno', 'lineno', 'module',
         'msecs', 'msg', 'name', 'pathname', 'process',
-        'processName', 'relativeCreated', 'stack_info', 'thread', 'threadName']
+        'processName', 'relativeCreated', 'stack_info', 'thread', 'threadName'}
     # fields to be set on the top-level of a Logstash event/message, do not modify this
     # unless you know what you are doing
     FORMATTER_LOGSTASH_MESSAGE_FIELD_LIST = [

--- a/logstash_async/formatter.py
+++ b/logstash_async/formatter.py
@@ -133,7 +133,9 @@ class LogstashFormatter(logging.Formatter):
 
     # ----------------------------------------------------------------------
     def _get_record_fields(self, record):
-        return {k: self._value_repr(v) for k, v in record.__dict__.items()}
+        return {k: self._value_repr(v)
+                for k, v in record.__dict__.items()
+                if k not in constants.FORMATTER_RECORD_FIELD_SKIP_LIST}
 
     # ----------------------------------------------------------------------
     def _value_repr(self, value):

--- a/tests/formatter_test.py
+++ b/tests/formatter_test.py
@@ -29,6 +29,15 @@ class LogstashFormatterTest(unittest.TestCase):
 
         self.assertIsNone(file_handler.exception)
 
+    def test_fields_are_excluded_in_get_record_fields(self):
+        formatter = LogstashFormatter()
+        log_record = makeLogRecord({
+            'filename': 'foo.py',
+            'dummy': 'foobar'
+        })
+        self.assertDictEqual(formatter._get_record_fields(log_record), {
+            'dummy': 'foobar'
+        })
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In my hunt for a bottleneck in one of our applications, I've found another few hotspots. Not that it was _slow_ before, but when you push a few thousand messages per minute, some things just pop up.

This PR contains two small but measurable improvements. My approach was a simple `timeit` script, run standalone and with a profiler:

```
    result = timeit.timeit(stmt="""formatter.format(lr)""",
                           setup="""
from logstash_async.formatter import LogstashFormatter
from logging import LogRecord, Logger
import datetime
import logging

now = datetime.datetime.now()
formatter = LogstashFormatter()
lr = Logger('dummy-logger').makeRecord(
    'Some name', logging.ERROR, 'blubb.py', 123, 'Some message',
    args=(), exc_info=None,
    extra={'foo': 'bar', 'baz': 123, 'somedatetime': now})
""",
                           number=100000)
    print(result)
```

With the current 2.3.0, this script completed (on my machine) in around 2.6 seconds.

The first change was to change `FORMATTER_RECORD_FIELD_SKIP_LIST` to a set: this list is used in the fashion of `x in y` which is way faster for sets than list. This brought the execution time down to 2.2 seconds.

The other change was to exclude fields from `FORMATTER_RECORD_FIELD_SKIP_LIST` in `_get_record_fields`: The formatter pulled all fields from the `message` and the `extra` into the dict and removed the fields afterwards in `_remove_excluded_fields`. Since we're iterating over `__dict__.items()` in `_get_record_fields` anyway, we can skip the fields right there and save us the `del` later on.
With both changes, I'm down to 1.7 seconds.

I'm working on another improvement involving the datetime handling, but that will come in another PR as it involves a little bit more code.