### PR TITLE
Update link to docs for rate limit string notation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -363,7 +363,7 @@ for easy modification.
     of the same errors. In case rate limiting is in effect, the last message before dropping further
     messages will contain a hint telling that further messages of this kind will be dropped.
     To disable set this to `None`, to enable use a string like '5 per minute',
-    for details see http://limits.readthedocs.io/en/stable/string-notation.html.
+    for details see https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation.
 
     .. note::
         This rate limit affects only error log messages emitted directly in


### PR DESCRIPTION
The [current link][code_ref] to the docs for rate limit string notation returns a 404. This pull request updates the link.

[code_ref]: https://github.com/eht16/python-logstash-async/blame/a1b800b8169a28a06b9477430d147530e52aa1fc/docs/config.rst#L366