### PR TITLE
The _close method has been separately overridden for UdpTransport and TcpTransport

### DIFF
--- a/logstash_async/transport.py
+++ b/logstash_async/transport.py
@@ -133,7 +133,7 @@ class UdpTransport:
         if not self._keep_connection or force:
             if self._sock:
                 try:
-                    self._wait_for_socket_buffer_empty()
+                    #self._wait_for_socket_buffer_empty()
                     self._try_to_close_socket()
                 finally:
                     self._sock = None
@@ -163,7 +163,7 @@ class UdpTransport:
     # ----------------------------------------------------------------------
     def _try_to_close_socket(self):
         try:
-            self._sock.shutdown(socket.SHUT_WR)
+            #self._sock.shutdown(socket.SHUT_WR)
             self._sock.close()
         except Exception as exc:
             self._log_close_socket_error(exc)
@@ -199,6 +199,15 @@ class TcpTransport(UdpTransport):
         self._certfile = certfile
         self._ca_certs = ca_certs
         self._timeout = timeout
+    # ----------------------------------------------------------------------
+    def _close(self, force=False):
+        if not self._keep_connection or force:
+            if self._sock:
+                try:
+                    self._wait_for_socket_buffer_empty()
+                    self._try_to_close_socket()
+                finally:
+                    self._sock = None
 
     # ----------------------------------------------------------------------
     def _create_socket(self):


### PR DESCRIPTION
"The close method is overridden separately for UDP protocol because the shutdown of a UDP connection does not require cleaning up with wait_for_socket_buffer_empty, or using _sock.shutdown(socket.SHUT_WR) method. This avoids encountering connection errors when working with UDP, such as: 'Error on closing the transport socket: [Errno 107] Transport endpoint is not connected.'"
This explanation highlights the necessity of customizing the closing behavior for different protocols to ensure optimal performance and error handling. In the case of UDP, which is a connectionless protocol, certain steps taken for connection-oriented protocols like TCP (such as waiting for the socket buffer to empty or shutting down the write direction of the socket) are not applicable and can be omitted to prevent potential errors.